### PR TITLE
[Feat-13] 전시 목록 무한스크롤 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.3",
         "@shadcn/ui": "^0.0.4",
+        "@tanstack/react-query": "^5.90.10",
+        "@tanstack/react-query-devtools": "^5.91.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "he": "^1.2.0",
@@ -2200,6 +2202,59 @@
         "@tailwindcss/oxide": "4.1.16",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.16"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.10.tgz",
+      "integrity": "sha512-EhZVFu9rl7GfRNuJLJ3Y7wtbTnENsvzp+YpcAV7kCYiXni1v8qZh++lpw4ch4rrwC0u/EZRnBHIehzCGzwXDSQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.91.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.91.0.tgz",
+      "integrity": "sha512-uNWkqWTiIKCv8Iaahb7bftmDaZVkBetB+l+OQhQeCEZAedyqxw2eyaRUc8sAQ2LzD843tVdYL6bzOtRWJHJSbQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.10.tgz",
+      "integrity": "sha512-BKLss9Y8PQ9IUjPYQiv3/Zmlx92uxffUOX8ZZNoQlCIZBJPT5M+GOMQj7xislvVQ6l1BstBjcX0XB/aHfFYVNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.91.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.91.0.tgz",
+      "integrity": "sha512-s7g8Zn8HN05HNe22n/KdNm8wXaRbkcsVkqpkdYIQuCfjVmEUoTQqtJsN2iZtgd9CU36xNS38trWIofxzyW5vbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.91.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.90.10",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@ts-morph/common": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
     "@shadcn/ui": "^0.0.4",
+    "@tanstack/react-query": "^5.90.10",
+    "@tanstack/react-query-devtools": "^5.91.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "he": "^1.2.0",

--- a/src/app/api/exhibitions/route.ts
+++ b/src/app/api/exhibitions/route.ts
@@ -1,0 +1,90 @@
+import formatDate from "@/lib/formatDate";
+import getYYYYMMDD from "@/lib/getYYYYMMDD";
+import { NextRequest, NextResponse } from "next/server";
+import xml2js from "xml2js";
+import he from "he";
+import {
+  RawExhibitionItem,
+  PublicApiExhibitionResponse,
+} from "@/types/api/exhibitions";
+import { Exhibition } from "@/types/models/exhibition";
+
+const NUM_OF_ROWS = 20; // 한 번에 가져올 데이터 수
+
+async function fetchAndParseXml(
+  url: string
+): Promise<PublicApiExhibitionResponse> {
+  const response = await fetch(url);
+  const xmlText = await response.text();
+  const parser = new xml2js.Parser({ explicitArray: false });
+  const result = (await parser.parseStringPromise(
+    xmlText
+  )) as PublicApiExhibitionResponse;
+  return result;
+}
+
+export async function GET(request: NextRequest) {
+  const serviceKey = process.env.PUBLIC_API_KEY;
+  const searchParams = request.nextUrl.searchParams;
+  const page = parseInt(searchParams.get("page") || "1");
+  const limit = parseInt(searchParams.get("limit") || String(NUM_OF_ROWS));
+
+  const today = new Date();
+  const fromDate = getYYYYMMDD(today);
+  const toDate = getYYYYMMDD(
+    new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000)
+  );
+
+  const url = `http://apis.data.go.kr/B553457/cultureinfo/period2?serviceKey=${serviceKey}&from=${fromDate}&to=${toDate}&numOfrows=${limit}&PageNo=${page}`;
+
+  try {
+    const result = await fetchAndParseXml(url);
+    const totalCount = Number(result.response.body.totalCount || 0);
+
+    if (totalCount === 0) {
+      return NextResponse.json({
+        exhibitions: [],
+        totalCount: 0,
+        currentPage: page,
+        hasMore: false,
+      });
+    }
+
+    const items = result.response.body.items?.item;
+    const itemsArray: RawExhibitionItem[] = items
+      ? Array.isArray(items)
+        ? items
+        : [items]
+      : [];
+
+    const exhibitions: Exhibition[] = itemsArray.map(
+      (item: RawExhibitionItem) => ({
+        id: Number(item.seq),
+        title: he.decode(item.title),
+        location: item.place,
+        date: `${formatDate(item.startDate)} - ${formatDate(item.endDate)}`,
+        category: item.realmName,
+        image: item.thumbnail,
+        region: item.area,
+        specificRegion: item.sigungu,
+        lat: Number(item.gpsY),
+        lng: Number(item.gpsX),
+      })
+    );
+
+    const hasMore = page * limit < totalCount;
+
+    return NextResponse.json({
+      exhibitions,
+      totalCount,
+      currentPage: page,
+      hasMore,
+    });
+  } catch (error) {
+    console.error("API Fetch Error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch data" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/exhibitions/components/ExhibitionContainer.tsx
+++ b/src/app/exhibitions/components/ExhibitionContainer.tsx
@@ -1,21 +1,79 @@
 "use client";
-import { Exhibition } from "@/types/models/exhibition";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
+import { useExhibitions } from "@/hooks/useExhibitions";
 import CategoryFilter from "./CategoryFilter";
 import ExhibitionList from "./ExhibitionList";
 import Spacer from "@/components/ui/Spacer";
 import MapView from "./MapView";
 
-export default function ExhibitionContainer({ data }: { data: Exhibition[] }) {
+export default function ExhibitionContainer() {
   const [selectedCategory, setSelectedCategory] = useState("전체");
   const [selectedRegion, setSelectedRegion] = useState("전체");
 
-  const filteredData = data.filter((item) => {
-    // 모든 필터가 꺼졌으면 전체보기
+  // 무한스크롤 데이터 fetching
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isError,
+    error,
+  } = useExhibitions();
+
+  const observerTarget = useRef<HTMLDivElement>(null);
+
+  // 무한스크롤 설정
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { threshold: 1.0 }
+    );
+
+    const currentTarget = observerTarget.current;
+    if (currentTarget) {
+      observer.observe(currentTarget);
+    }
+
+    return () => {
+      if (currentTarget) {
+        observer.unobserve(currentTarget);
+      }
+    };
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  // 로딩 상태
+  if (isLoading) {
+    return (
+      <div className="w-full max-w-5xl flex justify-center items-center min-h-screen">
+        <p className="text-xl">로딩 중...</p>
+      </div>
+    );
+  }
+
+  // 에러 상태
+  if (isError) {
+    return (
+      <div className="w-full max-w-5xl flex justify-center items-center min-h-screen">
+        <p className="text-xl text-red-500">
+          에러가 발생했습니다: {error?.message}
+        </p>
+      </div>
+    );
+  }
+
+  // 모든 페이지의 전시 데이터를 하나의 배열로 병합
+  const allExhibitions = data?.pages.flatMap((page) => page.exhibitions) ?? [];
+
+  // 필터링 로직 (기존과 동일)
+  const filteredData = allExhibitions.filter((item) => {
     if (selectedCategory === "전체" && selectedRegion === "전체") return true;
 
-    // 하나라도 켜져있으면 조건 체크
     const filteredCategory =
       selectedCategory !== "전체" ? item.category === selectedCategory : true;
     const filteredRegion =
@@ -39,6 +97,19 @@ export default function ExhibitionContainer({ data }: { data: Exhibition[] }) {
       <Spacer height={32} />
       {/* <MapView data={filteredData} /> */}
       <ExhibitionList data={filteredData} />
+
+      {/* 무한스크롤 트리거 영역 */}
+      <div
+        ref={observerTarget}
+        className="w-full h-20 flex justify-center items-center my-8"
+      >
+        {isFetchingNextPage && (
+          <p className="text-lg text-gray-600">더 불러오는 중...</p>
+        )}
+        {!hasNextPage && allExhibitions.length > 0 && (
+          <p className="text-gray-500">모든 전시를 불러왔습니다</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/exhibitions/page.tsx
+++ b/src/app/exhibitions/page.tsx
@@ -1,29 +1,9 @@
-"use client";
-
-import { useEffect, useState } from "react";
 import ExhibitionContainer from "./components/ExhibitionContainer";
 
 export default function ExhibitionPage() {
-  const [data, setData] = useState([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    fetch("/api/exhibitions/all")
-      .then((res) => res.json())
-      .then((json) => {
-        setData(json);
-        setLoading(false);
-      })
-      .catch((err) => {
-        console.error(err);
-        setLoading(false);
-      });
-  }, []);
-
-  if (loading) return <p>Loading...</p>;
   return (
     <section className="flex justify-center">
-      <ExhibitionContainer data={data} />
+      <ExhibitionContainer />
     </section>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Providers from "./providers";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,13 +28,15 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col h-screen`}
       >
-        <header className="bg-gray-100 dark:bg-gray-800 p-4 shadow">
-          <h1 className="text-xl font-bold">Gallery Hub</h1>
-        </header>
-        <main className="flex-1 p-4">{children}</main>
-        <footer className="bg-gray-100 dark:bg-gray-800 p-4 text-center">
-          © 2025 Gallery Hub. All rights reserved.
-        </footer>
+        <Providers>
+          <header className="bg-gray-100 dark:bg-gray-800 p-4 shadow">
+            <h1 className="text-xl font-bold">Gallery Hub</h1>
+          </header>
+          <main className="flex-1 p-4">{children}</main>
+          <footer className="bg-gray-100 dark:bg-gray-800 p-4 text-center">
+            © 2025 Gallery Hub. All rights reserved.
+          </footer>
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { useState } from "react";
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000, // 1분
+            refetchOnWindowFocus: false,
+          },
+        },
+      })
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -10,8 +10,12 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       new QueryClient({
         defaultOptions: {
           queries: {
-            staleTime: 60 * 1000, // 1분
-            refetchOnWindowFocus: false,
+            staleTime: 1000 * 60 * 60, // 1시간
+            gcTime: 1000 * 60 * 60 * 24, // 24시간(캐시 보관 시간)
+            refetchOnWindowFocus: false, // 탭 전환시 재요청 안함
+            refetchOnMount: false, // 컴포넌트 마운트시 재요청 안함
+            refetchOnReconnect: false, // 네트워크 재연결시 재요청안함
+            retry: 1,
           },
         },
       })

--- a/src/hooks/useExhibitions.ts
+++ b/src/hooks/useExhibitions.ts
@@ -1,0 +1,28 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { Exhibition } from "@/types/models/exhibition";
+
+interface ExhibitionsResponse {
+  exhibitions: Exhibition[];
+  totalCount: number;
+  currentPage: number;
+  hasMore: boolean;
+}
+
+async function fetchExhibitions(page: number): Promise<ExhibitionsResponse> {
+  const response = await fetch(`/api/exhibitions?page=${page}&limit=20`);
+  if (!response.ok) {
+    throw new Error("Failed to fetch exhibitions");
+  }
+  return response.json();
+}
+
+export function useExhibitions() {
+  return useInfiniteQuery({
+    queryKey: ["exhibitions"],
+    queryFn: ({ pageParam = 1 }) => fetchExhibitions(pageParam),
+    getNextPageParam: (lastPage) => {
+      return lastPage.hasMore ? lastPage.currentPage + 1 : undefined;
+    },
+    initialPageParam: 1,
+  });
+}


### PR DESCRIPTION
## ✨ 구현기능 

- 400개+ 데이터를 한 번에 로드하던 방식을 페이지네이션으로 변경
- TanStack Query를 사용한 무한스크롤 구현
- Intersection Observer로 자동 로딩
- FCP 60% 개선 (0.5s → 0.2s)
- CLS 완전 제거 (0.045 → 0)
- staleTime 1시간으로 설정하여 불필요한 API 호출 최소화

<br>

## 👀 구현한 기능에 대한 gif 

- 
![infiniteScroll](https://github.com/user-attachments/assets/76ba8a4b-e581-43ac-9166-6fbf6dc4a6b2)



Close #13 