### PR TITLE
[Feat-18] 전시회 상세 페이지 구현

### DIFF
--- a/src/app/api/exhibitions/[id]/route.ts
+++ b/src/app/api/exhibitions/[id]/route.ts
@@ -20,7 +20,10 @@ async function fetchAndParseXml(
   return result;
 }
 
-export async function GET({ params }: { params: Promise<{ id: string }> }) {
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
   const serviceKey = process.env.PUBLIC_API_KEY;
   const { id: exhibitionId } = await params;
 

--- a/src/app/api/exhibitions/[id]/route.ts
+++ b/src/app/api/exhibitions/[id]/route.ts
@@ -1,0 +1,53 @@
+import { PublicApiExhibitionDetailResponse } from "@/types/api/exhibitionDetail";
+import { NextResponse } from "next/server";
+import xml2js from "xml2js";
+
+/**
+ * @param url 요청할 API URL
+ * @returns 공공 API 응답 구조를 따르는 객체
+ */
+async function fetchAndParseXml(
+  url: string
+): Promise<PublicApiExhibitionDetailResponse> {
+  const response = await fetch(url);
+  const xmlText = await response.text();
+
+  // xml → json 변환
+  const parser = new xml2js.Parser({ explicitArray: false });
+  const result = (await parser.parseStringPromise(
+    xmlText
+  )) as PublicApiExhibitionDetailResponse;
+  return result;
+}
+
+export async function GET({ params }: { params: Promise<{ id: string }> }) {
+  const serviceKey = process.env.PUBLIC_API_KEY;
+  const { id: exhibitionId } = await params;
+
+  const baseUrl = `http://apis.data.go.kr/B553457/cultureinfo/detail2?serviceKey=${serviceKey}&seq=${exhibitionId}`;
+
+  try {
+    const result = await fetchAndParseXml(baseUrl);
+    const item = result?.response.body.items?.item;
+    if (!item) {
+      return NextResponse.json(
+        { error: "Exhibition not found" },
+        { status: 404 }
+      );
+    }
+
+    const cleanedItem = JSON.parse(JSON.stringify(item));
+
+    return NextResponse.json(cleanedItem);
+  } catch (e) {
+    console.error(e);
+    return NextResponse.json(
+      {
+        error: "Failed to fetch exhibition detail",
+      },
+      {
+        status: 500,
+      }
+    );
+  }
+}

--- a/src/app/exhibitions/[id]/components/ExhibitionDescription.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionDescription.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+
+interface ExhibitionDescriptionProps {
+  content: string;
+}
+
+export function ExhibitionDescription({ content }: ExhibitionDescriptionProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const previewLength = 200;
+  const shouldTruncate = content.length > previewLength;
+  const displayText = isExpanded ? content : content.slice(0, previewLength);
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm md:text-base text-foreground leading-relaxed whitespace-pre-wrap">
+        {displayText}
+        {shouldTruncate && !isExpanded && "..."}
+      </p>
+      {shouldTruncate && (
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="text-primary text-sm font-semibold hover:underline"
+        >
+          {isExpanded ? "Read Less" : "Read More"}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/app/exhibitions/[id]/components/ExhibitionDetail.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionDetail.tsx
@@ -2,7 +2,7 @@
 
 import { useExhibitionsDetail } from "@/hooks/useExhibitionsDetail";
 import { ExhibitionDetailHeader } from "./ExhibitionHeader";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ExhibitionTags } from "./ExhibitionTags";
 import Image from "next/image";
 import { ExhibitionInfoItem } from "./ExhibitionInfoItem";
@@ -13,10 +13,18 @@ import { Calendar, MapPin } from "lucide-react";
 import he from "he";
 import formatPhoneForTel from "@/lib/formatPhoneForTel";
 import formatDate from "@/lib/formatDate";
+import sanitizeImageUrl from "@/lib/sanitizeImageUrl";
 
 export default function ExhibitionDetail({ id }: { id: string }) {
   const { data, isLoading, error } = useExhibitionsDetail(id);
   const [isFavorite, setIsFavorite] = useState(false);
+  const [imageSrc, setImageSrc] = useState<string>("/images/placeholder.svg");
+
+  useEffect(() => {
+    if (data?.imgUrl) {
+      setImageSrc(sanitizeImageUrl(data.imgUrl));
+    }
+  }, [data?.imgUrl]);
 
   if (isLoading) return <div>로딩중</div>;
   if (error) return <div>에러 발생</div>;
@@ -41,11 +49,15 @@ export default function ExhibitionDetail({ id }: { id: string }) {
         <div className="flex flex-col gap-4">
           <div className="relative w-full aspect-[2/3] rounded-lg overflow-hidden bg-muted/30">
             <Image
-              src={data.imgUrl || "/placeholder.svg"}
+              src={imageSrc}
               alt={he.decode(data.title)}
               fill
               className="object-cover"
               priority
+              onError={() => {
+                console.log("이미지 로드 실패:", imageSrc);
+                setImageSrc("/images/placeholder.svg");
+              }}
             />
           </div>
 

--- a/src/app/exhibitions/[id]/components/ExhibitionDetail.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionDetail.tsx
@@ -16,7 +16,7 @@ import formatDate from "@/lib/formatDate";
 import sanitizeImageUrl from "@/lib/sanitizeImageUrl";
 
 export default function ExhibitionDetail({ id }: { id: string }) {
-  const { data, isLoading, error } = useExhibitionsDetail(id);
+  const { data } = useExhibitionsDetail(id);
   const [isFavorite, setIsFavorite] = useState(false);
   const [imageSrc, setImageSrc] = useState<string>("/images/placeholder.svg");
 
@@ -25,10 +25,6 @@ export default function ExhibitionDetail({ id }: { id: string }) {
       setImageSrc(sanitizeImageUrl(data.imgUrl));
     }
   }, [data?.imgUrl]);
-
-  if (isLoading) return <div>로딩중</div>;
-  if (error) return <div>에러 발생</div>;
-  if (!data) return <div>데이터를 찾을 수 없습니다</div>;
 
   const startDateFormatted = formatDate(data.startDate);
   const endDateFormatted = formatDate(data.endDate);

--- a/src/app/exhibitions/[id]/components/ExhibitionDetail.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionDetail.tsx
@@ -63,7 +63,9 @@ export default function ExhibitionDetail({ id }: { id: string }) {
               {he.decode(data.title)}
             </h2>
             <p className="text-sm text-muted-foreground mb-4">
-              {data.realmName} • {data.area} {data.sigungu}
+              {data.realmName}
+              {(data.area || data.sigungu) && " • "}
+              {[data.area, data.sigungu].filter(Boolean).join(" ")}
             </p>
             <ExhibitionTags tags={[data.realmName, data.area, "Exhibition"]} />
           </div>
@@ -77,7 +79,9 @@ export default function ExhibitionDetail({ id }: { id: string }) {
               {he.decode(data.title)}
             </h2>
             <p className="text-base text-muted-foreground mb-4">
-              {data.realmName} • {data.area} {data.sigungu}
+              {data.realmName}
+              {(data.area || data.sigungu) && " • "}
+              {[data.area, data.sigungu].filter(Boolean).join(" ")}
             </p>
             <ExhibitionTags tags={[data.realmName, data.area, "Exhibition"]} />
           </div>

--- a/src/app/exhibitions/[id]/components/ExhibitionDetail.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionDetail.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useExhibitionsDetail } from "@/hooks/useExhibitionsDetail";
+import { ExhibitionDetailHeader } from "./ExhibitionHeader";
+import { useState } from "react";
+import { ExhibitionTags } from "./ExhibitionTags";
+import Image from "next/image";
+import { ExhibitionInfoItem } from "./ExhibitionInfoItem";
+import { Button } from "@/components/ui/button";
+import { ExhibitionDescription } from "./ExhibitionDescription";
+import { ExhibitionLocation } from "./ExhibitionLocation";
+import { Calendar, MapPin } from "lucide-react";
+import he from "he";
+import formatPhoneForTel from "@/lib/formatPhoneForTel";
+import formatDate from "@/lib/formatDate";
+
+export default function ExhibitionDetail({ id }: { id: string }) {
+  const { data, isLoading, error } = useExhibitionsDetail(id);
+  const [isFavorite, setIsFavorite] = useState(false);
+
+  if (isLoading) return <div>로딩중</div>;
+  if (error) return <div>에러 발생</div>;
+  if (!data) return <div>데이터를 찾을 수 없습니다</div>;
+
+  const startDateFormatted = formatDate(data.startDate);
+  const endDateFormatted = formatDate(data.endDate);
+  const dateRange = `${startDateFormatted} - ${endDateFormatted}`;
+
+  const telNumber = formatPhoneForTel(data.phone);
+
+  return (
+    <div className="min-h-screen bg-background max-w-[1200px] mx-auto">
+      <ExhibitionDetailHeader
+        title="Exhibition Details"
+        isFavorite={isFavorite}
+        onFavoriteToggle={() => setIsFavorite(!isFavorite)}
+      />
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8">
+        {/* Image Section */}
+        <div className="flex flex-col gap-4">
+          <div className="relative w-full aspect-[2/3] rounded-lg overflow-hidden bg-muted/30">
+            <Image
+              src={data.imgUrl || "/placeholder.svg"}
+              alt={he.decode(data.title)}
+              fill
+              className="object-cover"
+              priority
+            />
+          </div>
+
+          {/* Mobile Info - shown on mobile, hidden on desktop */}
+          <div className="lg:hidden">
+            <h2 className="text-2xl font-bold text-foreground mb-2">
+              {he.decode(data.title)}
+            </h2>
+            <p className="text-sm text-muted-foreground mb-4">
+              {data.realmName} • {data.area} {data.sigungu}
+            </p>
+            <ExhibitionTags tags={[data.realmName, data.area, "Exhibition"]} />
+          </div>
+        </div>
+
+        {/* Content Section */}
+        <div className="space-y-6">
+          {/* Desktop Title - hidden on mobile */}
+          <div className="hidden lg:block">
+            <h2 className="text-3xl font-bold text-foreground mb-2">
+              {he.decode(data.title)}
+            </h2>
+            <p className="text-base text-muted-foreground mb-4">
+              {data.realmName} • {data.area} {data.sigungu}
+            </p>
+            <ExhibitionTags tags={[data.realmName, data.area, "Exhibition"]} />
+          </div>
+
+          {/* Info Items */}
+          <div className="space-y-4">
+            <ExhibitionInfoItem
+              icon={<Calendar className="w-5 h-5" />}
+              label="날짜"
+              value={dateRange}
+            />
+            <ExhibitionInfoItem
+              icon={<MapPin className="w-5 h-5" />}
+              label="장소"
+              value={data.place}
+            />
+            {/* [TODO] 돈 이모티콘 통일성에 맞게 변경하기 */}
+            <ExhibitionInfoItem
+              icon={<div className="text-lg font-semibold">💵</div>}
+              label="가격"
+              value={data.price}
+            />
+          </div>
+
+          <Button
+            asChild
+            className="w-full h-12 md:h-14 text-base md:text-lg font-semibold rounded-lg"
+          >
+            <a href={data.url} target="_blank" rel="noopener noreferrer">
+              홈페이지 이동하기
+            </a>
+          </Button>
+
+          {/* Description */}
+          <div className="border-t border-border pt-4">
+            <h3 className="text-base md:text-lg font-semibold text-foreground mb-3">
+              About
+            </h3>
+            <ExhibitionDescription content={data.contents1} />
+          </div>
+
+          {/* Contact Info */}
+          <div className="bg-muted rounded-lg p-4 space-y-2">
+            <p className="text-sm text-muted-foreground">Contact</p>
+            <p className="text-sm md:text-base font-medium text-foreground">
+              <a href={`tel:${telNumber}`} className="hover:underline">
+                {data.phone}
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Location Section - Full Width */}
+      <div className="mt-8 lg:mt-12 border-t border-border pt-8 lg:pt-12">
+        <ExhibitionLocation
+          address={data.placeAddr}
+          placeUrl={data.placeUrl}
+          lat={data.gpsY}
+          lng={data.gpsX}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/exhibitions/[id]/components/ExhibitionHeader.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionHeader.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ArrowLeft, Heart, Share2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useRouter } from "next/navigation";
+
+interface ExhibitionDetailHeaderProps {
+  title: string;
+  onShare?: () => void;
+  isFavorite?: boolean;
+  onFavoriteToggle?: () => void;
+}
+
+export function ExhibitionDetailHeader({
+  title,
+  onShare,
+  isFavorite = false,
+  onFavoriteToggle,
+}: ExhibitionDetailHeaderProps) {
+  const router = useRouter();
+
+  return (
+    <div className="flex items-center justify-between gap-2 mb-6">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => router.back()}
+        className="rounded-full hover:cursor-pointer"
+      >
+        <ArrowLeft className="w-6 h-6" />
+      </Button>
+      <h1 className="flex-1 text-center text-md md:text-base font-semibold text-gray-800">
+        {title}
+      </h1>
+      <div className="flex items-center gap-2">
+        {/* [todo] 추후 좋아요 및 공유하기 버튼 기능 구현 후 버튼 활성화 */}
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onFavoriteToggle}
+          className="rounded-full invisible"
+        >
+          <Heart
+            className="w-5 h-5"
+            fill={isFavorite ? "currentColor" : "none"}
+          />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onShare}
+          className="rounded-full invisible"
+        >
+          <Share2 className="w-5 h-5" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/exhibitions/[id]/components/ExhibitionInfoItem.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionInfoItem.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+interface ExhibitionInfoItemProps {
+  icon: ReactNode;
+  label: string;
+  value: string;
+}
+
+export function ExhibitionInfoItem({
+  icon,
+  label,
+  value,
+}: ExhibitionInfoItemProps) {
+  return (
+    <div className="flex gap-3 md:gap-4">
+      <div className="flex-shrink-0 flex items-center justify-center w-10 h-10 md:w-12 md:h-12 rounded-full bg-primary/10">
+        <div className="text-primary">{icon}</div>
+      </div>
+      <div className="flex-1">
+        <p className="text-xs md:text-sm text-muted-foreground mb-1">{label}</p>
+        <p
+          className={`text-sm md:text-base font-semibold text-base ${
+            value ? "text-gray-900" : "text-gray-400 italic"
+          }`}
+        >
+          {value || "정보 없음"}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/exhibitions/[id]/components/ExhibitionLocation.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionLocation.tsx
@@ -1,0 +1,84 @@
+import { MapPin } from "lucide-react";
+import { useEffect, useRef } from "react";
+
+interface ExhibitionLocationProps {
+  address: string;
+  placeUrl?: string;
+  lat?: string;
+  lng?: string;
+}
+
+export function ExhibitionLocation({
+  address,
+  placeUrl,
+  lat,
+  lng,
+}: ExhibitionLocationProps) {
+  const mapRef = useRef<HTMLDivElement>(null);
+
+  // 유효한 좌표인지 확인
+  const hasValidCoordinates =
+    lat !== undefined && lng !== undefined && lat !== "" && lng !== "";
+  console.log(lat, lng);
+  useEffect(() => {
+    if (!hasValidCoordinates) return;
+
+    // 카카오맵 로드
+    window.kakao?.maps.load(() => {
+      if (!mapRef.current) return;
+
+      const options = {
+        center: new window.kakao.maps.LatLng(parseFloat(lat), parseFloat(lng)),
+        level: 3,
+      };
+
+      const map = new window.kakao.maps.Map(mapRef.current, options);
+
+      // 마커 추가
+      const markerPosition = new window.kakao.maps.LatLng(
+        parseFloat(lat),
+        parseFloat(lng)
+      );
+      const marker = new window.kakao.maps.Marker({
+        position: markerPosition,
+      });
+      marker.setMap(map);
+    });
+  }, [lat, lng, hasValidCoordinates]);
+
+  // 좌표가 없는 경우
+  if (!hasValidCoordinates) {
+    return (
+      <div className="space-y-3">
+        <h3 className="text-base md:text-lg font-semibold">Location</h3>
+        <div className="relative w-full h-48 md:h-64 rounded-lg overflow-hidden bg-muted/30 flex items-center justify-center">
+          <div className="text-center">
+            <MapPin className="w-12 h-12 mx-auto text-primary/50 mb-3" />
+            <p className="text-sm text-muted-foreground">위치 정보 없음</p>
+          </div>
+        </div>
+        <p className="text-sm">{address || "주소 정보 없음"}</p>
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      <h3 className="text-base md:text-lg font-semibold">Location</h3>
+      <div
+        ref={mapRef}
+        className="relative w-full h-48 md:h-64 rounded-lg overflow-hidden"
+      />
+      <p className="text-sm">{address}</p>
+      {placeUrl && (
+        <a
+          href={`${placeUrl}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-primary hover:underline"
+        >
+          공식 홈페이지 →
+        </a>
+      )}
+    </div>
+  );
+}

--- a/src/app/exhibitions/[id]/components/ExhibitionTags.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionTags.tsx
@@ -5,14 +5,16 @@ interface ExhibitionTagsProps {
 export function ExhibitionTags({ tags }: ExhibitionTagsProps) {
   return (
     <div className="flex flex-wrap gap-2">
-      {tags.map((tag, index) => (
-        <span
-          key={index}
-          className="inline-block px-3 py-1 text-xs md:text-sm font-medium rounded-full bg-primary/10 text-primary"
-        >
-          {tag}
-        </span>
-      ))}
+      {tags
+        .filter((tag) => tag && tag.trim() !== "")
+        .map((tag, index) => (
+          <span
+            key={index}
+            className="inline-block px-3 py-1 text-xs md:text-sm font-medium rounded-full bg-primary/10 text-primary"
+          >
+            {tag}
+          </span>
+        ))}
     </div>
   );
 }

--- a/src/app/exhibitions/[id]/components/ExhibitionTags.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionTags.tsx
@@ -1,0 +1,18 @@
+interface ExhibitionTagsProps {
+  tags: string[];
+}
+
+export function ExhibitionTags({ tags }: ExhibitionTagsProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {tags.map((tag, index) => (
+        <span
+          key={index}
+          className="inline-block px-3 py-1 text-xs md:text-sm font-medium rounded-full bg-primary/10 text-primary"
+        >
+          {tag}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/app/exhibitions/[id]/page.tsx
+++ b/src/app/exhibitions/[id]/page.tsx
@@ -1,4 +1,6 @@
+import { Suspense } from "react";
 import ExhibitionDetail from "./components/ExhibitionDetail";
+import { ErrorBoundary } from "react-error-boundary";
 
 export default async function ExhibitionDetailPage({
   params,
@@ -6,5 +8,24 @@ export default async function ExhibitionDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  return <ExhibitionDetail id={id} />;
+  return (
+    <ErrorBoundary
+      fallback={
+        <div className="w-full flex justify-center items-center min-h-screen">
+          <p className="text-xl text-red-500">에러가 발생했습니다</p>
+        </div>
+      }
+    >
+      <Suspense
+        fallback={
+          <div className="w-full max-w-5xl flex justify-center items-center min-h-screen">
+            <p className="text-xl">로딩 중...</p>
+          </div>
+        }
+      >
+        {" "}
+        <ExhibitionDetail id={id} />
+      </Suspense>
+    </ErrorBoundary>
+  );
 }

--- a/src/app/exhibitions/[id]/page.tsx
+++ b/src/app/exhibitions/[id]/page.tsx
@@ -1,0 +1,10 @@
+import ExhibitionDetail from "./components/ExhibitionDetail";
+
+export default async function ExhibitionDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  return <ExhibitionDetail id={id} />;
+}

--- a/src/app/exhibitions/components/ExhibitionCard.tsx
+++ b/src/app/exhibitions/components/ExhibitionCard.tsx
@@ -1,14 +1,21 @@
 import { Exhibition } from "@/types/models/exhibition";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import sanitizeImageUrl from "@/lib/sanitizeImageUrl";
 
 export default function ExhibitionCard({ item }: { item: Exhibition }) {
-  const [imageSrc, setImageSrc] = useState(item.image);
+  const [imageSrc, setImageSrc] = useState<string>(item.image);
   const area = [item.region, item.specificRegion].filter(Boolean).join(" ");
   const hasLocation = Boolean(item.location);
   const locationText = area + (hasLocation ? ` | ${item.location}` : "");
   const showIcon = area || hasLocation;
+
+  useEffect(() => {
+    if (item?.image) {
+      setImageSrc(sanitizeImageUrl(item?.image));
+    }
+  }, [item?.image]);
 
   return (
     <Link

--- a/src/app/exhibitions/components/ExhibitionCard.tsx
+++ b/src/app/exhibitions/components/ExhibitionCard.tsx
@@ -1,6 +1,7 @@
 import { Exhibition } from "@/types/models/exhibition";
 import { useState } from "react";
 import Image from "next/image";
+import Link from "next/link";
 
 export default function ExhibitionCard({ item }: { item: Exhibition }) {
   const [imageSrc, setImageSrc] = useState(item.image);
@@ -10,7 +11,10 @@ export default function ExhibitionCard({ item }: { item: Exhibition }) {
   const showIcon = area || hasLocation;
 
   return (
-    <div className="group overflow-hidden rounded-lg border border-border bg-card shadow-sm hover:shadow-md transition-shadow">
+    <Link
+      href={`/exhibitions/${item.id}`}
+      className="group block overflow-hidden rounded-lg border border-border bg-card shadow-sm hover:shadow-md transition-shadow"
+    >
       {/* Image Container */}
       <div className="relative w-full h-48 bg-muted overflow-hidden">
         {imageSrc ? (
@@ -86,6 +90,6 @@ export default function ExhibitionCard({ item }: { item: Exhibition }) {
           </div>
         </div>
       </div>
-    </div>
+    </Link>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Providers from "./providers";
+import Script from "next/script";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -25,6 +26,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <Script
+          src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_KEY}&autoload=false`}
+          strategy="beforeInteractive"
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col h-screen`}
       >

--- a/src/hooks/useExhibitionsDetail.ts
+++ b/src/hooks/useExhibitionsDetail.ts
@@ -1,10 +1,12 @@
 import { ExhibitionDetail } from "@/types/api/exhibitionDetail";
-import { useQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 
 async function fetchExhibitionsDetail(id: string): Promise<ExhibitionDetail> {
   const baseUrl =
     typeof window === "undefined"
-      ? process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+      ? process.env.VERCEL_URL
+        ? `https://${process.env.VERCEL_URL}`
+        : "http://localhost:3000"
       : "";
 
   const response = await fetch(`${baseUrl}/api/exhibitions/${id}`);
@@ -15,10 +17,10 @@ async function fetchExhibitionsDetail(id: string): Promise<ExhibitionDetail> {
 }
 
 export function useExhibitionsDetail(id: string) {
-  return useQuery({
+  return useSuspenseQuery({
     queryKey: ["exhibition", id],
     queryFn: () => fetchExhibitionsDetail(id),
-    enabled: !!id,
-    staleTime: 1000 * 60 * 5,
+    staleTime: 1000 * 60 * 60 * 24, // 1일
+    gcTime: 1000 * 60 * 60 * 24 * 7, // 1일
   });
 }

--- a/src/hooks/useExhibitionsDetail.ts
+++ b/src/hooks/useExhibitionsDetail.ts
@@ -1,0 +1,24 @@
+import { ExhibitionDetail } from "@/types/api/exhibitionDetail";
+import { useQuery } from "@tanstack/react-query";
+
+async function fetchExhibitionsDetail(id: string): Promise<ExhibitionDetail> {
+  const baseUrl =
+    typeof window === "undefined"
+      ? process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000"
+      : "";
+
+  const response = await fetch(`${baseUrl}/api/exhibitions/${id}`);
+  if (!response.ok) {
+    throw new Error("Failed to fetch exhibitions");
+  }
+  return response.json();
+}
+
+export function useExhibitionsDetail(id: string) {
+  return useQuery({
+    queryKey: ["exhibition", id],
+    queryFn: () => fetchExhibitionsDetail(id),
+    enabled: !!id,
+    staleTime: 1000 * 60 * 5,
+  });
+}

--- a/src/lib/formatPhoneForTel.ts
+++ b/src/lib/formatPhoneForTel.ts
@@ -1,0 +1,8 @@
+export default function formatPhoneForTel(phone?: string) {
+  if (!phone) return "";
+
+  const match = phone.match(/\d{2,4}-\d{3,4}-\d{4}/);
+  if (!match) return "";
+
+  return match[0].replace(/-/g, "");
+}

--- a/src/lib/sanitizeImageUrl.ts
+++ b/src/lib/sanitizeImageUrl.ts
@@ -1,0 +1,38 @@
+/** 
+ 이미지 URL을 정제합니다.
+ 공공 API에서 중복된 prefix가 포함된 URL을 수정합니다.
+
+ @param url - 정제할 이미지 URL
+@returns 정제된 URL 또는 placeholder 이미지 경로
+
+@example
+정상적인 URL
+sanitizeImageUrl("http://example.com/image.jpg")
+→ "http://example.com/image.jpg"
+
+ @example
+ 중복 prefix가 있는 URL
+sanitizeImageUrl("http://www.culture.go.kr/upload/rdf/http://www.kopis.or.kr/image.jpg")
+→ "http://www.kopis.or.kr/image.jpg"
+ */
+
+const sanitizeImageUrl = (url: string | null | undefined) => {
+  if (!url) return "/images/placeholder.svg";
+
+  // http:// 가 2개 이상 있는지 체크
+  const matches = url.match(/http:\/\//g);
+
+  if (matches && matches.length >= 2) {
+    // 두 번째 http:// 위치 찾기
+    const firstIndex = url.indexOf("http://");
+    const secondIndex = url.indexOf("http://", firstIndex + 1);
+
+    // 두 번째 http://부터 끝까지 반환
+    return url.substring(secondIndex);
+  }
+
+  // 정상적인 URL은 그대로 반환
+  return url;
+};
+
+export default sanitizeImageUrl;

--- a/src/types/api/exhibitionDetail.ts
+++ b/src/types/api/exhibitionDetail.ts
@@ -1,0 +1,36 @@
+export interface ExhibitionDetail {
+  seq: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  place: string;
+  realmName: string;
+  area: string;
+  price: string;
+  contents1: string;
+  url: string;
+  phone: string;
+  gpsX: string;
+  gpsY: string;
+  imgUrl: string;
+  placeUrl: string;
+  placeAddr: string;
+  placeSeq: string;
+  sigungu: string;
+}
+
+export interface ExhibitionDetailBody {
+  items: {
+    item: ExhibitionDetail;
+  };
+}
+
+export interface PublicApiExhibitionDetailResponse {
+  response: {
+    header: {
+      resultCode: string;
+      resultMsg: string;
+    };
+    body: ExhibitionDetailBody;
+  };
+}

--- a/src/types/kakao.d.ts
+++ b/src/types/kakao.d.ts
@@ -15,7 +15,7 @@ declare namespace kakao.maps {
   }
 
   class Marker {
-    constructor(options: { map: Map; position: LatLng; title?: string });
+    constructor(options: { map?: Map; position: LatLng; title?: string });
     setMap(map: Map | null): void;
     setPosition(position: LatLng): void;
   }


### PR DESCRIPTION
## ✨ 구현기능

- 상세페이지 구현하기
    - 상세페이지 이벤트 핸들러 작성하기(api/exhibitions/[id]/route.ts)
    - useSuspenseQuery 작성하기(src/hooks/useExhibitionDetail.ts )
        - queryKey 및 stale, gc 설정
      
- 상세페이지 제작하기
    -  상세페이지 생성(src/ap/exhibitions/[id]/page.tsx), params로 id값 받기
    - UI 구현하기
        - ExhibitionHedaer.tsx: 헤더
        - ExhibitionInfoItem.tsx: 날짜, 장소, 가격 정보
        - ExhibitionLocation.tsx: 위치
        - ExhibitionTags.tsx: 카테고리 등 태그 정보
        - ExhibitionDescription.tsx: 상세 설명
        - ExhibitionDetail.tsx: 위 컴포넌트들에 대한 컨테이너 컴포넌트, 이미지 없는 경우 예외처리
     
- 상세페이지 연결하기
    - link 태그로 연결(src/app/exhibitions/components/ExhibitionCard.tsx)
  
     




## 👀 구현한 기능에 대한 gif

-
![detail](https://github.com/user-attachments/assets/9146f4f3-c21f-4fd0-9183-e97ea7644bb8)

## 📋 관련 이슈

Close #18 
