### PR TITLE
[Feat-25] 로그인 상태 유지 및 보호 라우터, 로그인 토스트 알림 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-dom": "19.1.0",
         "react-error-boundary": "^6.0.0",
         "shadcn": "^3.5.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "tw-animate-css": "^1.4.0",
@@ -8961,6 +8962,16 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-dom": "19.1.0",
     "react-error-boundary": "^6.0.0",
     "shadcn": "^3.5.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "tw-animate-css": "^1.4.0",

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -1,0 +1,3 @@
+export default function FavoritesPage() {
+  return <div>찜 목록 리스트</div>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import Providers from "./providers";
 import Script from "next/script";
 import { Header } from "@/components/Header";
+import ToasterProvider from "./toasterProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -44,6 +45,7 @@ export default function RootLayout({
           <footer className="bg-gray-100 dark:bg-gray-800 p-4 text-center">
             © 2025 Gallery Hub. All rights reserved.
           </footer>
+          <ToasterProvider />
         </Providers>
       </body>
     </html>

--- a/src/app/login/components/Form.tsx
+++ b/src/app/login/components/Form.tsx
@@ -2,19 +2,29 @@
 
 import type React from "react";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Eye, EyeOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 import { useLogin } from "@/hooks/useLogin";
+import { useSearchParams } from "next/navigation";
+import { toast } from "sonner";
 
 export function LoginForm() {
   const [showPassword, setShowPassword] = useState(false);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-
   const { mutate: login, isPending, error, isError } = useLogin();
+
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const redirect = searchParams.get("redirect");
+    if (redirect === "true") {
+      toast.error("로그인이 필요합니다.");
+    }
+  }, [searchParams]);
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -36,7 +46,6 @@ export function LoginForm() {
             로그인하고 갤러리 허브를 탐색해보세요.
           </p>
         </div>
-
         {/* Login Form */}
         <form onSubmit={handleLogin} className="space-y-4">
           {/* Email */}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,10 @@
 import { LoginForm } from "./components/Form";
+import { Suspense } from "react";
 
 export default function LoginPage() {
-  return <LoginForm />;
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <LoginForm />
+    </Suspense>
+  );
 }

--- a/src/app/toasterProvider.tsx
+++ b/src/app/toasterProvider.tsx
@@ -1,0 +1,12 @@
+"use client";
+import { Toaster } from "sonner";
+
+export default function ToasterProvider() {
+  return (
+    <Toaster
+      position="top-right"
+      richColors
+      toastOptions={{ style: { zIndex: 9999 } }}
+    />
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const token = request.cookies.get("token");
+
+  if (!token) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/favorites/:path*"],
+};

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,7 +5,9 @@ export function proxy(request: NextRequest) {
   const token = request.cookies.get("token");
 
   if (!token) {
-    return NextResponse.redirect(new URL("/login", request.url));
+    const url = new URL("/login", request.url);
+    url.searchParams.set("redirect", "true");
+    return NextResponse.redirect(url);
   }
 
   return NextResponse.next();

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const token = request.cookies.get("token");
 
   if (!token) {

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 interface AuthState {
   isLoggedIn: boolean;
@@ -8,10 +9,17 @@ interface AuthState {
   logout: () => void;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
-  isLoggedIn: false,
-  user: null,
+export const useAuthStore = create<AuthState>()(
+  persist(
+    (set) => ({
+      isLoggedIn: false,
+      user: null,
 
-  login: (email) => set({ isLoggedIn: true, user: { email } }),
-  logout: () => set({ isLoggedIn: false, user: null }),
-}));
+      login: (email) => set({ isLoggedIn: true, user: { email } }),
+      logout: () => set({ isLoggedIn: false, user: null }),
+    }),
+    {
+      name: "auth-storage",
+    }
+  )
+);


### PR DESCRIPTION
## ✨ 구현기능

- `zustand` persist 미들웨어 적용하여 새로고침 후에도 로그인 상태 유지
- `proxy.ts` 파일 생성, 토큰이 없는 경우 `redirect=true` 쿼리를 붙여 로그인 페이지로 이동시키는 보호 라우터 구현 (`/favorites`: 좋아요 목록)
- `sonner` 토스트 라이브러리 설치 및 로그인 페이지 이동 시 알림 적용


## 👀 구현한 기능에 대한 gif

-
![redirect](https://github.com/user-attachments/assets/2d9ee34f-3d47-400a-a468-da140e020a22)

## 📋 관련 이슈

Close #25 
