### PR TITLE
[Feat-40] Exhibition Detail 페이지 LCP 및 초기 렌더링 성능 개선

### DIFF
--- a/src/app/exhibitions/[id]/components/ExhibitionDescriptionSection.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionDescriptionSection.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { memo } from "react";
+import { ExhibitionDescription } from "./ExhibitionDescription";
+
+interface ExhibitionDescriptionSectionProps {
+  contents: string;
+  phone: string;
+  telNumber: string;
+}
+
+export const ExhibitionDescriptionSection = memo(
+  ({ contents, phone, telNumber }: ExhibitionDescriptionSectionProps) => {
+    return (
+      <>
+        <div className="border-t border-border pt-4">
+          <h3 className="text-base md:text-lg font-semibold text-foreground mb-3">
+            About
+          </h3>
+          <ExhibitionDescription content={contents} />
+        </div>
+
+        <div className="bg-muted rounded-lg p-4 space-y-2">
+          <p className="text-sm text-muted-foreground">Contact</p>
+          <p className="text-sm md:text-base font-medium text-foreground">
+            <a href={`tel:${telNumber}`} className="hover:underline">
+              {phone}
+            </a>
+          </p>
+        </div>
+      </>
+    );
+  }
+);
+
+ExhibitionDescriptionSection.displayName = "ExhibitionDescriptionSection";

--- a/src/app/exhibitions/[id]/components/ExhibitionDetail.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionDetail.tsx
@@ -2,14 +2,13 @@
 
 import { useExhibitionsDetail } from "@/hooks/useExhibitionsDetail";
 import { ExhibitionDetailHeader } from "./ExhibitionHeader";
-import { useEffect, useState } from "react";
+import { memo, useCallback, useMemo } from "react";
 import { ExhibitionTags } from "./ExhibitionTags";
-import Image from "next/image";
-import { ExhibitionInfoItem } from "./ExhibitionInfoItem";
 import { Button } from "@/components/ui/button";
-import { ExhibitionDescription } from "./ExhibitionDescription";
+import { ExhibitionInfoSection } from "./ExhibitionInfoSection";
 import { ExhibitionLocation } from "./ExhibitionLocation";
-import { Calendar, MapPin } from "lucide-react";
+import { ImageSection } from "./ExhibitionImageSection";
+import { ExhibitionDescriptionSection } from "./ExhibitionDescriptionSection";
 import he from "he";
 import formatPhoneForTel from "@/lib/formatPhoneForTel";
 import formatDate from "@/lib/formatDate";
@@ -24,31 +23,41 @@ import { useRouter } from "next/navigation";
 
 export default function ExhibitionDetail({ id }: { id: string }) {
   const { data } = useExhibitionsDetail(id);
-  const { mutate: addWishlist, isPending: addPending } = useAddWishList();
-  const { user, isAuthenticated, loading } = useAuth();
+  const { isAuthenticated } = useAuth();
+  const router = useRouter();
+
   const { data: checkWishListData, isLoading: checkWishListIsLoading } =
     useCheckWishList(id);
+
+  const { mutate: addWishlist, isPending: addPending } = useAddWishList();
   const { mutate: removeWishlist, isPending: removePending } =
     useRemoveWishList();
-  const router = useRouter();
+
   const isWishlisted = checkWishListData?.isWishlisted ?? false;
   const isPending = addPending || removePending;
 
-  const [isFavorite, setIsFavorite] = useState(isWishlisted);
-  const [imageSrc, setImageSrc] = useState<string>("/images/placeholder.svg");
+  const tags = useMemo(
+    () => [data.realmName, data.area].filter(Boolean),
+    [data.realmName, data.area]
+  );
 
-  useEffect(() => {
-    if (data?.imgUrl) {
-      setImageSrc(sanitizeImageUrl(data.imgUrl));
-    }
+  const imageSrc = useMemo(() => {
+    if (!data?.imgUrl) return "/images/placeholder.svg";
+    return sanitizeImageUrl(data.imgUrl);
   }, [data?.imgUrl]);
 
-  const startDateFormatted = formatDate(data.startDate);
-  const endDateFormatted = formatDate(data.endDate);
-  const dateRange = `${startDateFormatted} - ${endDateFormatted}`;
-  const telNumber = formatPhoneForTel(data.phone);
+  const dateRange = useMemo(() => {
+    if (!data?.startDate || !data?.endDate) return "";
+    const start = formatDate(data.startDate);
+    const end = formatDate(data.endDate);
+    return `${start} - ${end}`;
+  }, [data?.startDate, data?.endDate]);
 
-  const handleAddWishlist = () => {
+  const telNumber = useMemo(() => {
+    return formatPhoneForTel(data?.phone);
+  }, [data?.phone]);
+
+  const handleAddWishlist = useCallback(() => {
     if (!isAuthenticated) {
       const url = new URL("/login", window.location.origin);
       url.searchParams.set("redirect", "true");
@@ -61,17 +70,38 @@ export default function ExhibitionDetail({ id }: { id: string }) {
     } else {
       addWishlist({
         item_id: id,
-        item_type: data.realmName,
+        item_type: data?.realmName,
       });
     }
-  };
+  }, [
+    isAuthenticated,
+    isWishlisted,
+    id,
+    data?.realmName,
+    router,
+    removeWishlist,
+    addWishlist,
+  ]);
+
+  const titleSection = (
+    <>
+      <h2 className="text-2xl lg:text-3xl font-bold text-foreground mb-2">
+        {he.decode(data?.title)}
+      </h2>
+      <p className="text-sm lg:text-base text-muted-foreground mb-4">
+        {data?.realmName}
+        {(data?.area || data?.sigungu) && " • "}
+        {[data?.area, data?.sigungu].filter(Boolean).join(" ")}
+      </p>
+      <ExhibitionTags tags={tags} />
+    </>
+  );
 
   return (
     <div className="bg-background max-w-[1200px] w-full mx-auto">
       <ExhibitionDetailHeader
         title="Exhibition Details"
-        isFavorite={isFavorite}
-        onFavoriteToggle={() => setIsFavorite(!isFavorite)}
+        isFavorite={isWishlisted}
         addWishlist={handleAddWishlist}
         isPending={isPending}
         checkWishListIsLoading={checkWishListIsLoading}
@@ -79,69 +109,16 @@ export default function ExhibitionDetail({ id }: { id: string }) {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8">
         {/* Image Section */}
-        <div className="flex flex-col gap-4">
-          <div className="relative w-full aspect-[2/3] rounded-lg overflow-hidden bg-muted/30">
-            <Image
-              src={imageSrc}
-              alt={he.decode(data.title)}
-              fill
-              className="object-cover"
-              priority
-              onError={() => {
-                console.log("이미지 로드 실패:", imageSrc);
-                setImageSrc("/images/placeholder.svg");
-              }}
-            />
-          </div>
-
-          {/* Mobile Info - shown on mobile, hidden on desktop */}
-          <div className="lg:hidden">
-            <h2 className="text-2xl font-bold text-foreground mb-2">
-              {he.decode(data.title)}
-            </h2>
-            <p className="text-sm text-muted-foreground mb-4">
-              {data.realmName}
-              {(data.area || data.sigungu) && " • "}
-              {[data.area, data.sigungu].filter(Boolean).join(" ")}
-            </p>
-            <ExhibitionTags tags={[data.realmName, data.area, "Exhibition"]} />
-          </div>
-        </div>
-
+        <ImageSection imageSrc={imageSrc} title={data.title} />
         {/* Content Section */}
         <div className="space-y-6">
-          {/* Desktop Title - hidden on mobile */}
-          <div className="hidden lg:block">
-            <h2 className="text-3xl font-bold text-foreground mb-2">
-              {he.decode(data.title)}
-            </h2>
-            <p className="text-base text-muted-foreground mb-4">
-              {data.realmName}
-              {(data.area || data.sigungu) && " • "}
-              {[data.area, data.sigungu].filter(Boolean).join(" ")}
-            </p>
-            <ExhibitionTags tags={[data.realmName, data.area, "Exhibition"]} />
-          </div>
-
+          {titleSection}
           {/* Info Items */}
-          <div className="space-y-4">
-            <ExhibitionInfoItem
-              icon={<Calendar className="w-5 h-5" />}
-              label="날짜"
-              value={dateRange}
-            />
-            <ExhibitionInfoItem
-              icon={<MapPin className="w-5 h-5" />}
-              label="장소"
-              value={data.place}
-            />
-            {/* [TODO] 돈 이모티콘 통일성에 맞게 변경하기 */}
-            <ExhibitionInfoItem
-              icon={<div className="text-lg font-semibold">💵</div>}
-              label="가격"
-              value={data.price}
-            />
-          </div>
+          <ExhibitionInfoSection
+            dateRange={dateRange}
+            place={data.place}
+            price={data.price}
+          />
 
           <Button
             asChild
@@ -153,22 +130,11 @@ export default function ExhibitionDetail({ id }: { id: string }) {
           </Button>
 
           {/* Description */}
-          <div className="border-t border-border pt-4">
-            <h3 className="text-base md:text-lg font-semibold text-foreground mb-3">
-              About
-            </h3>
-            <ExhibitionDescription content={data.contents1} />
-          </div>
-
-          {/* Contact Info */}
-          <div className="bg-muted rounded-lg p-4 space-y-2">
-            <p className="text-sm text-muted-foreground">Contact</p>
-            <p className="text-sm md:text-base font-medium text-foreground">
-              <a href={`tel:${telNumber}`} className="hover:underline">
-                {data.phone}
-              </a>
-            </p>
-          </div>
+          <ExhibitionDescriptionSection
+            contents={data.contents1}
+            phone={data.phone}
+            telNumber={telNumber}
+          />
         </div>
       </div>
 

--- a/src/app/exhibitions/[id]/components/ExhibitionHeader.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionHeader.tsx
@@ -3,68 +3,69 @@
 import { ArrowLeft, Heart, Share2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
+import { memo } from "react";
 
 interface ExhibitionDetailHeaderProps {
   title: string;
   onShare?: () => void;
   isFavorite?: boolean;
-  onFavoriteToggle?: () => void;
   addWishlist: () => void;
   isPending: boolean;
   checkWishListIsLoading: boolean;
 }
 
-export function ExhibitionDetailHeader({
-  title,
-  onShare,
-  isFavorite = false,
-  onFavoriteToggle,
-  addWishlist,
-  isPending,
-  checkWishListIsLoading,
-}: ExhibitionDetailHeaderProps) {
-  const router = useRouter();
+export const ExhibitionDetailHeader = memo(
+  ({
+    title,
+    onShare,
+    isFavorite = false,
+    addWishlist,
+    isPending,
+    checkWishListIsLoading,
+  }: ExhibitionDetailHeaderProps) => {
+    const router = useRouter();
 
-  const onClickFavoriteBtn = () => {
-    onFavoriteToggle?.();
-    addWishlist();
-  };
-
-  return (
-    <div className="flex items-center justify-between gap-2 mb-6">
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={() => router.back()}
-        className="rounded-full hover:cursor-pointer"
-      >
-        <ArrowLeft className="w-6 h-6" />
-      </Button>
-      <h1 className="flex-1 text-center text-md md:text-base font-semibold text-gray-800">
-        {title}
-      </h1>
-      <div className="flex items-center gap-2">
+    const onClickFavoriteBtn = () => {
+      addWishlist();
+    };
+    return (
+      <div className="flex items-center justify-between gap-2 mb-6">
         <Button
           variant="ghost"
           size="icon"
-          onClick={onClickFavoriteBtn}
-          className="rounded-full cursor-pointer"
-          disabled={isPending || checkWishListIsLoading}
+          onClick={() => router.back()}
+          className="rounded-full hover:cursor-pointer"
         >
-          <Heart
-            className="w-5 h-5"
-            fill={isFavorite ? "currentColor" : "none"}
-          />
+          <ArrowLeft className="w-6 h-6" />
         </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onShare}
-          className="rounded-full cursor-pointer"
-        >
-          <Share2 className="w-5 h-5" />
-        </Button>
+        <h1 className="flex-1 text-center text-md md:text-base font-semibold text-gray-800">
+          {title}
+        </h1>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onClickFavoriteBtn}
+            className="rounded-full cursor-pointer"
+            disabled={isPending || checkWishListIsLoading}
+          >
+            <Heart
+              className="w-5 h-5"
+              fill={isFavorite ? "currentColor" : "none"}
+            />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onShare}
+            className="rounded-full cursor-pointer"
+          >
+            <Share2 className="w-5 h-5" />
+          </Button>
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }
+);
+
+ExhibitionDetailHeader.displayName = "ExhibitionDetailHeader";

--- a/src/app/exhibitions/[id]/components/ExhibitionImageSection.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionImageSection.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Image from "next/image";
+import { memo } from "react";
+import he from "he";
+
+interface ExhibitionImageSectionProps {
+  imageSrc: string;
+  title: string;
+}
+
+export const ImageSection = memo(
+  ({ imageSrc, title }: ExhibitionImageSectionProps) => {
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="relative w-full aspect-[2/3] rounded-lg overflow-hidden bg-muted/30">
+          <Image
+            src={imageSrc}
+            alt={he.decode(title)}
+            fill
+            className="object-cover"
+            priority
+          />
+        </div>
+      </div>
+    );
+  }
+);
+ImageSection.displayName = "ImageSection";

--- a/src/app/exhibitions/[id]/components/ExhibitionInfoItem.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionInfoItem.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 
 interface ExhibitionInfoItemProps {
   icon: ReactNode;
@@ -6,26 +6,28 @@ interface ExhibitionInfoItemProps {
   value: string;
 }
 
-export function ExhibitionInfoItem({
-  icon,
-  label,
-  value,
-}: ExhibitionInfoItemProps) {
-  return (
-    <div className="flex gap-3 md:gap-4">
-      <div className="flex-shrink-0 flex items-center justify-center w-10 h-10 md:w-12 md:h-12 rounded-full bg-primary/10">
-        <div className="text-primary">{icon}</div>
+export const ExhibitionInfoItem = memo(
+  ({ icon, label, value }: ExhibitionInfoItemProps) => {
+    return (
+      <div className="flex gap-3 md:gap-4">
+        <div className="flex-shrink-0 flex items-center justify-center w-10 h-10 md:w-12 md:h-12 rounded-full bg-primary/10">
+          <div className="text-primary">{icon}</div>
+        </div>
+        <div className="flex-1">
+          <p className="text-xs md:text-sm text-muted-foreground mb-1">
+            {label}
+          </p>
+          <p
+            className={`text-sm md:text-base font-semibold text-base ${
+              value ? "text-gray-900" : "text-gray-400 italic"
+            }`}
+          >
+            {value || "정보 없음"}
+          </p>
+        </div>
       </div>
-      <div className="flex-1">
-        <p className="text-xs md:text-sm text-muted-foreground mb-1">{label}</p>
-        <p
-          className={`text-sm md:text-base font-semibold text-base ${
-            value ? "text-gray-900" : "text-gray-400 italic"
-          }`}
-        >
-          {value || "정보 없음"}
-        </p>
-      </div>
-    </div>
-  );
-}
+    );
+  }
+);
+
+ExhibitionInfoItem.displayName = "ExhibitionInfoItem";

--- a/src/app/exhibitions/[id]/components/ExhibitionInfoSection.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionInfoSection.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { memo } from "react";
+import { Calendar, MapPin } from "lucide-react";
+import { ExhibitionInfoItem } from "./ExhibitionInfoItem";
+
+interface ExhibitionInfoSectionProps {
+  dateRange: string;
+  place: string;
+  price: string;
+}
+
+export const ExhibitionInfoSection = memo(
+  ({ dateRange, place, price }: ExhibitionInfoSectionProps) => {
+    return (
+      <div className="space-y-4">
+        <ExhibitionInfoItem
+          icon={<Calendar className="w-5 h-5" />}
+          label="날짜"
+          value={dateRange}
+        />
+        <ExhibitionInfoItem
+          icon={<MapPin className="w-5 h-5" />}
+          label="장소"
+          value={place}
+        />
+        <ExhibitionInfoItem
+          icon={<div className="text-lg font-semibold">💵</div>}
+          label="가격"
+          value={price}
+        />
+      </div>
+    );
+  }
+);
+
+ExhibitionInfoSection.displayName = "ExhibitionInfoSection";

--- a/src/app/exhibitions/[id]/components/ExhibitionLocation.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionLocation.tsx
@@ -1,5 +1,5 @@
 import { MapPin } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { memo, useEffect, useRef } from "react";
 
 interface ExhibitionLocationProps {
   address: string;
@@ -8,77 +8,79 @@ interface ExhibitionLocationProps {
   lng?: string;
 }
 
-export function ExhibitionLocation({
-  address,
-  placeUrl,
-  lat,
-  lng,
-}: ExhibitionLocationProps) {
-  const mapRef = useRef<HTMLDivElement>(null);
+export const ExhibitionLocation = memo(
+  ({ address, placeUrl, lat, lng }: ExhibitionLocationProps) => {
+    const mapRef = useRef<HTMLDivElement>(null);
 
-  // 유효한 좌표인지 확인
-  const hasValidCoordinates =
-    lat !== undefined && lng !== undefined && lat !== "" && lng !== "";
+    // 유효한 좌표인지 확인
+    const hasValidCoordinates =
+      lat !== undefined && lng !== undefined && lat !== "" && lng !== "";
 
-  useEffect(() => {
-    if (!hasValidCoordinates) return;
+    useEffect(() => {
+      if (!hasValidCoordinates) return;
 
-    // 카카오맵 로드
-    window.kakao?.maps.load(() => {
-      if (!mapRef.current) return;
+      // 카카오맵 로드
+      window.kakao?.maps.load(() => {
+        if (!mapRef.current) return;
 
-      const options = {
-        center: new window.kakao.maps.LatLng(parseFloat(lat), parseFloat(lng)),
-        level: 3,
-      };
+        const options = {
+          center: new window.kakao.maps.LatLng(
+            parseFloat(lat),
+            parseFloat(lng)
+          ),
+          level: 3,
+        };
 
-      const map = new window.kakao.maps.Map(mapRef.current, options);
+        const map = new window.kakao.maps.Map(mapRef.current, options);
 
-      // 마커 추가
-      const markerPosition = new window.kakao.maps.LatLng(
-        parseFloat(lat),
-        parseFloat(lng)
-      );
-      const marker = new window.kakao.maps.Marker({
-        position: markerPosition,
+        // 마커 추가
+        const markerPosition = new window.kakao.maps.LatLng(
+          parseFloat(lat),
+          parseFloat(lng)
+        );
+        const marker = new window.kakao.maps.Marker({
+          position: markerPosition,
+        });
+        marker.setMap(map);
       });
-      marker.setMap(map);
-    });
-  }, [lat, lng, hasValidCoordinates]);
+    }, [lat, lng, hasValidCoordinates]);
 
-  // 좌표가 없는 경우
-  if (!hasValidCoordinates) {
+    // 좌표가 없는 경우
+    if (!hasValidCoordinates) {
+      return (
+        <div className="space-y-3">
+          <h3 className="text-base md:text-lg font-semibold">Location</h3>
+          <div className="relative w-full h-48 md:h-64 rounded-lg overflow-hidden bg-muted/30 flex items-center justify-center">
+            <div className="text-center">
+              <MapPin className="w-12 h-12 mx-auto text-primary/50 mb-3" />
+              <p className="text-sm text-muted-foreground">위치 정보 없음</p>
+            </div>
+          </div>
+          <p className="text-sm">{address || "주소 정보 없음"}</p>
+        </div>
+      );
+    }
     return (
       <div className="space-y-3">
         <h3 className="text-base md:text-lg font-semibold">Location</h3>
-        <div className="relative w-full h-48 md:h-64 rounded-lg overflow-hidden bg-muted/30 flex items-center justify-center">
-          <div className="text-center">
-            <MapPin className="w-12 h-12 mx-auto text-primary/50 mb-3" />
-            <p className="text-sm text-muted-foreground">위치 정보 없음</p>
-          </div>
-        </div>
-        <p className="text-sm">{address || "주소 정보 없음"}</p>
+        <div
+          ref={mapRef}
+          className="relative w-full h-48 md:h-64 rounded-lg overflow-hidden"
+        />
+        <p className="text-sm">{address}</p>
+        {placeUrl && (
+          <a
+            href={`${placeUrl}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-primary hover:underline"
+          >
+            공식 홈페이지 →
+          </a>
+        )}
       </div>
     );
   }
-  return (
-    <div className="space-y-3">
-      <h3 className="text-base md:text-lg font-semibold">Location</h3>
-      <div
-        ref={mapRef}
-        className="relative w-full h-48 md:h-64 rounded-lg overflow-hidden"
-      />
-      <p className="text-sm">{address}</p>
-      {placeUrl && (
-        <a
-          href={`${placeUrl}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-xs text-primary hover:underline"
-        >
-          공식 홈페이지 →
-        </a>
-      )}
-    </div>
-  );
-}
+);
+
+ExhibitionLocation.displayName = "ExhibitionLocation";

--- a/src/app/exhibitions/[id]/components/ExhibitionTags.tsx
+++ b/src/app/exhibitions/[id]/components/ExhibitionTags.tsx
@@ -1,8 +1,10 @@
+import { memo } from "react";
+
 interface ExhibitionTagsProps {
   tags: string[];
 }
 
-export function ExhibitionTags({ tags }: ExhibitionTagsProps) {
+export const ExhibitionTags = memo(({ tags }: ExhibitionTagsProps) => {
   return (
     <div className="flex flex-wrap gap-2">
       {tags
@@ -17,4 +19,6 @@ export function ExhibitionTags({ tags }: ExhibitionTagsProps) {
         ))}
     </div>
   );
-}
+});
+
+ExhibitionTags.displayName = "ExhibitionTags";

--- a/src/app/exhibitions/[id]/page.tsx
+++ b/src/app/exhibitions/[id]/page.tsx
@@ -23,7 +23,6 @@ export default async function ExhibitionDetailPage({
           </div>
         }
       >
-        {" "}
         <ExhibitionDetail id={id} />
       </Suspense>
     </ErrorBoundary>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@
 import { useLogout } from "@/hooks/useLogout";
 import { useAuthStore } from "@/store/useAuthStore";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 
 export function Header() {
   const { isLoggedIn } = useAuthStore();
@@ -14,7 +15,9 @@ export function Header() {
 
   return (
     <header className="bg-gray-100 dark:bg-gray-800 p-4 shadow flex justify-between">
-      <h1 className="text-xl font-semibold">Gallery Hub</h1>
+      <h1 className="text-xl font-semibold">
+        <Link href="/exhibitions">Gallery Hub</Link>
+      </h1>
       {isLoggedIn ? (
         <button
           onClick={handleLogout}


### PR DESCRIPTION
## ✨ 구현기능

- Exhibition Detail 페이지의 초기 이미지 렌더링 구조 개선
- `useEffect + setState` 기반 이미지 로딩 로직 제거
- 이미지 src를 `useMemo`로 계산하여 최초 렌더 시점에 확정
- Detail 페이지 내부 UI를 섹션 단위 컴포넌트로 분리
  - ImageSection
  - ExhibitionInfoSection
  - ExhibitionDescriptionSection
- wishlist 관련 핸들러를 `useCallback`으로 안정화

## 핵심 개선 포인트
- LCP 대상이 되는 이미지가 최초 렌더 이후에 교체되는 구조를 제거
- 브라우저가 첫 페인트 시점부터 실제 이미지 다운로드를 시작할 수 있도록 개선
- 초기 렌더링 경로를 단순화하여 성능 측정 지표 개선


## 개선 전 / 후
| 항목 | Before | After |
|---|---|---|
| LCP | 약 1.7s | 약 0.7s |
| Lighthouse Performance | 93 | 100 |

## 👀 구현한 기능에 대한 gif
- 개선 전
<img width="712" height="1152" alt="스크린샷 2025-12-24 오후 10 27 36" src="https://github.com/user-attachments/assets/c0e518dd-e31b-4889-8d67-ea1dbd59ff21" />

- 개선 후
<img width="981" height="839" alt="스크린샷 2025-12-24 오후 10 26 56" src="https://github.com/user-attachments/assets/c2c71eb4-333a-43b3-90ee-1f68b85a21aa" />



## 📋 관련 이슈
Close #40 
