### PR TITLE
[Feat-44] 위시리스트 조회 로직 최적화로 불필요한 API 호출 제거

### DIFF
--- a/src/app/exhibitions/components/ExhibitionCard.tsx
+++ b/src/app/exhibitions/components/ExhibitionCard.tsx
@@ -5,26 +5,25 @@ import Link from "next/link";
 import sanitizeImageUrl from "@/lib/sanitizeImageUrl";
 import { Button } from "@/components/ui/button";
 import { Heart } from "lucide-react";
-import {
-  useAddWishList,
-  useCheckWishList,
-  useRemoveWishList,
-} from "@/hooks/useWishlist";
+import { useAddWishList, useRemoveWishList } from "@/hooks/useWishlist";
 
-export default function ExhibitionCard({ item }: { item: Exhibition }) {
+export default function ExhibitionCard({
+  item,
+  isWishlisted = false,
+}: {
+  item: Exhibition;
+  isWishlisted?: boolean;
+}) {
   const [imageSrc, setImageSrc] = useState<string>(item.image);
   const area = [item.region, item.specificRegion].filter(Boolean).join(" ");
   const hasLocation = Boolean(item.location);
   const locationText = area + (hasLocation ? ` | ${item.location}` : "");
   const showIcon = area || hasLocation;
 
-  const { data: checkWishListData, isLoading: checkWishListIsLoading } =
-    useCheckWishList(item.id);
   const { mutate: addWishlist, isPending: addPending } = useAddWishList();
   const { mutate: removeWishlist, isPending: removePending } =
     useRemoveWishList();
 
-  const isWishlisted = checkWishListData?.isWishlisted ?? false;
   const isPending = addPending || removePending;
 
   useEffect(() => {
@@ -79,7 +78,7 @@ export default function ExhibitionCard({ item }: { item: Exhibition }) {
             onClick={onClickFavoriteBtn}
             className="rounded-full cursor-pointer hover:bg-currentColor bg-white/20 backdrop-blur-sm shadow-lg"
             type="button"
-            disabled={isPending || checkWishListIsLoading}
+            disabled={isPending}
           >
             <Heart
               className="w-5 h-5"

--- a/src/app/exhibitions/components/ExhibitionContainer.tsx
+++ b/src/app/exhibitions/components/ExhibitionContainer.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useExhibitions } from "@/hooks/useExhibitions";
+import { useWishList } from "@/hooks/useWishlist";
 import CategoryFilter from "./CategoryFilter";
 import ExhibitionList from "./ExhibitionList";
 import Spacer from "@/components/ui/Spacer";
@@ -14,6 +15,10 @@ export default function ExhibitionContainer() {
   // 무한스크롤 데이터 fetching
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useExhibitions();
+  const { data: wishlistData } = useWishList();
+  const wishlistedIds = new Set(
+    wishlistData?.map((item) => item.item_id) || []
+  );
 
   const observerTarget = useRef<HTMLDivElement>(null);
 
@@ -69,7 +74,7 @@ export default function ExhibitionContainer() {
       />
       <Spacer height={32} />
       {/* <MapView data={filteredData} /> */}
-      <ExhibitionList data={filteredData} />
+      <ExhibitionList data={filteredData} wishlistedIds={wishlistedIds} />
 
       {/* 무한스크롤 트리거 영역 */}
       <div

--- a/src/app/exhibitions/components/ExhibitionList.tsx
+++ b/src/app/exhibitions/components/ExhibitionList.tsx
@@ -1,7 +1,13 @@
 import { Exhibition } from "@/types/models/exhibition";
 import ExhibitionCard from "./ExhibitionCard";
 
-export default function ExhibitionList({ data }: { data: Exhibition[] }) {
+export default function ExhibitionList({
+  data,
+  wishlistedIds,
+}: {
+  data: Exhibition[];
+  wishlistedIds?: Set<string>;
+}) {
   return (
     <div className="w-full">
       <h1 className="text-xl font-bold mb-8">
@@ -10,7 +16,11 @@ export default function ExhibitionList({ data }: { data: Exhibition[] }) {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 w-full">
         {data?.map((item) => (
-          <ExhibitionCard key={item.id} item={item} />
+          <ExhibitionCard
+            key={item.id}
+            item={item}
+            isWishlisted={wishlistedIds?.has(item.id) ?? false}
+          />
         ))}
       </div>
     </div>

--- a/src/app/favorites/components/FavoritedExhibitionsContainer.tsx
+++ b/src/app/favorites/components/FavoritedExhibitionsContainer.tsx
@@ -14,9 +14,11 @@ export default function FavoritedExhibitionsContainer() {
       </div>
     );
   const exhibitionData = convertWishlistArrayToExhibitions(data);
+  const allWishlistedIds = new Set(data.map((item) => item.item_id));
+
   return (
     <div className="w-full max-w-5xl flex flex-col items-center gap-2">
-      <ExhibitionList data={exhibitionData} />
+      <ExhibitionList data={exhibitionData} wishlistedIds={allWishlistedIds} />
     </div>
   );
 }


### PR DESCRIPTION
## ✨ 구현기능

- ExhibitionCard의 개별 위시리스트 체크 API 호출을 부모 컴포넌트의 배치 조회로 변경


## 👀 구현한 기능에 대한 gif

- 변경 전 
<img width="558" height="158" alt="스크린샷 2025-12-31 오후 7 18 27" src="https://github.com/user-attachments/assets/9641e461-b9a8-4093-ba61-caa0b24aa1a6" />

- 변경 후
<img width="541" height="35" alt="스크린샷 2025-12-31 오후 7 18 48" src="https://github.com/user-attachments/assets/bfe026b1-a2d2-4981-ae2b-14fc5aa72d50" />

## 🔧 주요 변경사항
### ExhibitionCard
- `isWishlisted` props 추가
- 개별 `useCheckWishList` 훅 제거

### ExhibitionContainer
- `useWishList` 훅으로 전체 위시리스트 조회
- Set 자료구조로 O(1) 검색 구현
- `wishlistedIds`를 ExhibitionList에 전달

### ExhibitionList
- `wishlistedIds` props 추가
- 각 카드에 `isWishlisted` 상태 전달

### FavoritedExhibitionsContainer
- 이미 위시리스트 데이터를 가지고 있으므로 그대로 활용

## 📊 성능 개선
- **Before**: 전시 9개 노출 시 API 호출 9번
- **After**: 전시 9개 시 API 호출 1번

## 📋 관련 이슈

Close #44 
