### PR TITLE
[Fix-49] 무한스크롤, 찜목록 data 없는 것으로 노출되는 문제 해결

### DIFF
--- a/src/app/exhibitions/components/ExhibitionContainer.tsx
+++ b/src/app/exhibitions/components/ExhibitionContainer.tsx
@@ -15,8 +15,14 @@ export default function ExhibitionContainer() {
   // 무한스크롤 데이터 fetching
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useExhibitions();
-  const { data: wishlistData = [], isLoading } = useWishList();
-  const wishlistedIds = new Set(wishlistData.map((item) => item.item_id));
+  const {
+    data: wishlistData = [],
+    isLoading,
+    isError: wishlistError,
+  } = useWishList();
+  const wishlistedIds = new Set(
+    wishlistError ? [] : wishlistData.map((item) => item.item_id)
+  );
 
   const observerTarget = useRef<HTMLDivElement>(null);
 

--- a/src/app/exhibitions/components/ExhibitionContainer.tsx
+++ b/src/app/exhibitions/components/ExhibitionContainer.tsx
@@ -13,15 +13,22 @@ export default function ExhibitionContainer() {
   const [selectedRegion, setSelectedRegion] = useState("전체");
 
   // 무한스크롤 데이터 fetching
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useExhibitions();
   const {
-    data: wishlistData = [],
-    isLoading,
-    isError: wishlistError,
-  } = useWishList();
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: exhibitionsLoading,
+  } = useExhibitions();
+
+  // wishlist는 에러가 나도 괜찮도록 처리
+  const { data: wishlistData = [], isError: wishlistError } = useWishList();
+
+  // wishlist 에러가 나도 빈 Set으로 처리
   const wishlistedIds = new Set(
-    wishlistError ? [] : wishlistData.map((item) => item.item_id)
+    wishlistError || !wishlistData
+      ? []
+      : wishlistData.map((item) => item.item_id)
   );
 
   const observerTarget = useRef<HTMLDivElement>(null);
@@ -52,7 +59,6 @@ export default function ExhibitionContainer() {
   // 모든 페이지의 전시 데이터를 하나의 배열로 병합
   const allExhibitions = data?.pages.flatMap((page) => page.exhibitions) ?? [];
 
-  // 필터링 로직 (기존과 동일)
   const filteredData = allExhibitions.filter((item) => {
     if (selectedCategory === "전체" && selectedRegion === "전체") return true;
 
@@ -64,8 +70,13 @@ export default function ExhibitionContainer() {
     return filteredCategory && filteredRegion;
   });
 
-  if (isLoading) {
-    return <div>로딩중...</div>;
+  // 전시 목록 로딩만 체크 (wishlist 로딩은 무시)
+  if (exhibitionsLoading) {
+    return (
+      <div className="w-full flex justify-center items-center py-20">
+        <p className="text-xl">로딩중...</p>
+      </div>
+    );
   }
 
   return (

--- a/src/app/favorites/components/FavoritedExhibitionsContainer.tsx
+++ b/src/app/favorites/components/FavoritedExhibitionsContainer.tsx
@@ -3,12 +3,25 @@
 import ExhibitionList from "@/app/exhibitions/components/ExhibitionList";
 import { convertWishlistArrayToExhibitions } from "@/lib/exhibitionAdapter";
 import { useWishList } from "@/hooks/useWishlist";
+import { useEffect } from "react";
 
 export default function FavoritedExhibitionsContainer() {
-  const { data, isLoading } = useWishList();
+  const { data, isLoading, isError, isFetching, refetch } = useWishList();
 
-  if (isLoading) {
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  if (isLoading || isFetching) {
     return <div>로딩중...</div>;
+  }
+
+  if (isError) {
+    return (
+      <div className="text-center py-20">
+        <p className="text-red-500">데이터를 불러오는데 실패했습니다</p>
+      </div>
+    );
   }
 
   if (!data || data?.length === 0)

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,11 +1,12 @@
 import { useAuthStore } from "@/store/useAuthStore";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
 export function useLogin() {
   const router = useRouter();
   const { login: setAuthState } = useAuthStore();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (credentials: { id: string; pw: string }) => {
@@ -23,9 +24,11 @@ export function useLogin() {
         throw new Error(data.message || "로그인에 실패했습니다.");
       return data;
     },
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       toast.success("로그인 성공!");
       setAuthState(data.user.email);
+      await queryClient.invalidateQueries({ queryKey: ["wishlist"] });
+      await queryClient.refetchQueries({ queryKey: ["wishlist"] });
       router.push("/exhibitions");
     },
     onError: (error: Error) => {

--- a/src/hooks/useWishlist.ts
+++ b/src/hooks/useWishlist.ts
@@ -158,7 +158,7 @@ export const useWishList = () => {
   return useQuery<WishlistItem[]>({
     queryKey: WISHLIST_KEYS.lists(),
     queryFn: wishlistAPI.list,
-    staleTime: 1000 * 60 * 5, // 5분
+    staleTime: 1000 * 60 * 5,
     gcTime: 1000 * 60 * 10, // 10분
     retry: 1,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
## 문제 상황
1. Favorites 페이지 데이터 로딩 문제
- 페이지 진입 시 DB에서 wishlist 데이터가 있음에도 불구하고 데이터를 불러오지 못함
2. 비로그인 상태에서 무한스크롤 작동 불가
- 로그인 하지 않은 상태에서 메인 리스트 페이지의 무한스크롤이 작동하지 않음


## ✨ 해결 방법

1. 로그인 성공 시 Wishlist 명시적 Refetch
[hooks/useLogin.ts]
```typescript:
// invalidate와 함께 refetch 실행
  await queryClient.invalidateQueries({ queryKey: ["wishlist"] });
  await queryClient.refetchQueries({ queryKey: ["wishlist"] });
```

2. 전시 목록 페이지 독립적 로딩 처리
[app/exhibitions/components/ExhibitionsContainer.tsx]
```typescript
// wishlist와 exhibitions 로딩 상태 분리
const { 
  data, 
  fetchNextPage, 
  hasNextPage, 
  isFetchingNextPage,
  isLoading: exhibitionsLoading  // 이름 명시
} = useExhibitions();

const {
  data: wishlistData = [],
  isError: wishlistError,
} = useWishList();

// wishlist 에러 시에도 빈 Set으로 처리
const wishlistedIds = new Set(
  wishlistError || !wishlistData ? [] : wishlistData.map((item) => item.item_id)
);

// 전시 목록 로딩만 체크 (wishlist 로딩 무시)
if (exhibitionsLoading) {
  return <div>로딩중...</div>;
}
```


## 📋 관련 이슈

Close #49 
